### PR TITLE
Enhanced: "readme file", "fallback" package naming, Added features: "Custom Fallback Namespace", "Click to Download"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Currently ComposerPress does not perform any control towards wpackagist [#2](htt
 
 3. You can always give an help and contribute... :smile:
 
+---
+
 ##### Author articles
 
 - <sub>[ComposerPress "Brief"](https://tomjn.com/2013/10/01/composerpress/)</sub>

--- a/README.md
+++ b/README.md
@@ -11,3 +11,16 @@ Includes support for composer packages via:
  - private git repositories
  - private svn repositories
  - non-composer plugins residing in git/svn/mercurial repositories
+
+---
+
+### Installation Notes
+Install as a regular plugin and then run <code>composer install</code> on the <code>wp-content/plugins/composerpress'</code> plugin folder to install dependencies.</p><p>For instructions on installing composer:</p><ul><li><a href="http://getcomposer.org/doc/00-intro.md#installation-nix"> see here for *nix</a></li><li><a href="http://getcomposer.org/doc/00-intro.md#installation-windows">here for Windows</a></li></ul>
+
+---
+
+##### Author articles
+
+- <sub>[ComposerPress "Brief"](https://tomjn.com/2013/10/01/composerpress/)</sub>
+- <sub>[Wordpress & Composer TLDR](https://tomjn.com/2015/09/03/wordpress-and-composer-tldr/)</sub>
+- <sub>[ComposerPress "Project"](https://tomjn.com/projects/composerpress/)</sub>

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Retroactively creates a composer.json for a WordPress site. On activation, a com
 
 Includes support for composer packages via:
 
- - packagist
- - wpackagist
- - private mercurial repositories
- - private git repositories
- - private svn repositories
+ - [packagist](https://packagist.org/)
+ - [wpackagist](https://wpackagist.org/)
+ - private [mercurial](https://en.wikipedia.org/wiki/Mercurial) repositories
+ - private [git](https://en.wikipedia.org/wiki/Git) repositories
+ - private [svn](https://en.wikipedia.org/wiki/Apache_Subversion) repositories
  - non-composer plugins residing in git/svn/mercurial repositories
 
 ---

--- a/README.md
+++ b/README.md
@@ -19,14 +19,6 @@ Install as a regular plugin and then run <code>composer install</code> on the <c
 
 ---
 
-##### Author articles
-
-- <sub>[ComposerPress "Brief"](https://tomjn.com/2013/10/01/composerpress/)</sub>
-- <sub>[Wordpress & Composer TLDR](https://tomjn.com/2015/09/03/wordpress-and-composer-tldr/)</sub>
-- <sub>[ComposerPress "Project"](https://tomjn.com/projects/composerpress/)</sub>
-
----
-
 ## TODOs:
 Currently ComposerPress does not perform any control towards wpackagist [#2](https://github.com/tomjn/composerpress/issues/2) (or similaries), leaving open these problems:
 - when a _TextDomain_ doesn't match a _Plugins Name_
@@ -44,3 +36,9 @@ Currently ComposerPress does not perform any control towards wpackagist [#2](htt
  - `Plugin URI: https://github.com/sanchothefat/wp-less/` that will become something like **_sanchothefat/wp-less_**
 
 3. You can always give an help and contribute... :smile:
+
+##### Author articles
+
+- <sub>[ComposerPress "Brief"](https://tomjn.com/2013/10/01/composerpress/)</sub>
+- <sub>[Wordpress & Composer TLDR](https://tomjn.com/2015/09/03/wordpress-and-composer-tldr/)</sub>
+- <sub>[ComposerPress "Project"](https://tomjn.com/projects/composerpress/)</sub>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Includes support for composer packages via:
 ---
 
 ### Installation Notes
-Install as a regular plugin and then run <code>composer install</code> on the <code>wp-content/plugins/composerpress'</code> plugin folder to install dependencies.</p><p>For instructions on installing composer:</p><ul><li><a href="http://getcomposer.org/doc/00-intro.md#installation-nix"> see here for *nix</a></li><li><a href="http://getcomposer.org/doc/00-intro.md#installation-windows">here for Windows</a></li></ul>
+Install as a regular plugin and then run <code>composer install</code> on the <code>wp-content/plugins/composerpress'</code> plugin folder to install dependencies.</p><p>For instructions on installing composer: <a href="http://getcomposer.org/doc/00-intro.md#installation-nix"> see here for *nix</a> and <a href="http://getcomposer.org/doc/00-intro.md#installation-windows">here for Windows</a></p>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Currently ComposerPress does not perform any control towards wpackagist [#2](htt
 
 ### Keep in mind
 
-1. At present, if composerpress can not find the source of a plugin, the choice will fall back on the defualt "composerpress" (to help you recognize them and act accordingly)
+1. At present, if composerpress can not find the source of a plugin, the choice will fall back on the default "composerpress" (to help you recognize them and act accordingly)
 
 2. If you encounter a false positive try to contact plugin's author  and ask him to insert, at least, a `Plugin URI:` in the header of the plugin; for example: these two plugins could collide if a URI plugin was not specified
   - `Plugin URI: http://wordpress.org/extend/plugins/wp-less/` that will become something like **_composerpress/wp-less_**

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Install as a regular plugin and then run <code>composer install</code> on the <c
 ---
 
 ## TODOs:
-Currently ComposerPress does not perform any control towards wpackagist https://github.com/tomjn/composerpress/issues/2 (or similaries), leaving open these problems:
+Currently ComposerPress does not perform any control towards wpackagist [#2](https://github.com/tomjn/composerpress/issues/2) (or similaries), leaving open these problems:
 - when a _TextDomain_ doesn't match a _Plugins Name_
 - when a plugin doesn't match its _Folder Name_
 - when a _Plugin is Custom to a site_ (ie doesn't exist in the wp.org repo)
@@ -39,6 +39,8 @@ Currently ComposerPress does not perform any control towards wpackagist https://
 
 1. At present, if composerpress can not find the source of a plugin, the choice will fall back on the defualt "composerpress" (to help you recognize them and act accordingly)
 
-2. if you encounter a false positive try to contact plugin's author  and ask him to insert, at least, a `Plugin URI:` in the header of the plugin; for example: these two plugins could collide if a URI plugin was not specified
+2. If you encounter a false positive try to contact plugin's author  and ask him to insert, at least, a `Plugin URI:` in the header of the plugin; for example: these two plugins could collide if a URI plugin was not specified
   - `Plugin URI: http://wordpress.org/extend/plugins/wp-less/` that will become something like **_composerpress/wp-less_**
  - `Plugin URI: https://github.com/sanchothefat/wp-less/` that will become something like **_sanchothefat/wp-less_**
+
+3. You can always give an help and contribute... :smile:

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Install as a regular plugin and then run <code>composer install</code> on the <c
 
 ## TODOs:
 Currently ComposerPress does not perform any control towards wpackagist [#2](https://github.com/tomjn/composerpress/issues/2) (or similaries), leaving open these problems:
-- when a _TextDomain_ doesn't match a _Plugins Name_
-- when a plugin doesn't match its _Folder Name_
-- when a _Plugin is Custom to a site_ (ie doesn't exist in the wp.org repo)
+- when a _TextDomain_ doesn't match a _Plugins Name_ ?
+- when a plugin doesn't match its _Folder Name_ ?
+- when a _Plugin is Custom to a site_ (ie doesn't exist in the wp.org repo) ?
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -24,3 +24,21 @@ Install as a regular plugin and then run <code>composer install</code> on the <c
 - <sub>[ComposerPress "Brief"](https://tomjn.com/2013/10/01/composerpress/)</sub>
 - <sub>[Wordpress & Composer TLDR](https://tomjn.com/2015/09/03/wordpress-and-composer-tldr/)</sub>
 - <sub>[ComposerPress "Project"](https://tomjn.com/projects/composerpress/)</sub>
+
+---
+
+## TODOs:
+Currently ComposerPress does not perform any control towards wpackagist https://github.com/tomjn/composerpress/issues/2 (or similaries), leaving open these problems:
+- when a _TextDomain_ doesn't match a _Plugins Name_
+- when a plugin doesn't match its _Folder Name_
+- when a _Plugin is Custom to a site_ (ie doesn't exist in the wp.org repo)
+
+---
+
+### Keep in mind
+
+1. At present, if composerpress can not find the source of a plugin, the choice will fall back on the defualt "composerpress" (to help you recognize them and act accordingly)
+
+2. if you encounter a false positive try to contact plugin's author  and ask him to insert, at least, a `Plugin URI:` in the header of the plugin; for example: these two plugins could collide if a URI plugin was not specified
+  - `Plugin URI: http://wordpress.org/extend/plugins/wp-less/` that will become something like **_composerpress/wp-less_**
+ - `Plugin URI: https://github.com/sanchothefat/wp-less/` that will become something like **_sanchothefat/wp-less_**

--- a/php/composerpress.php
+++ b/php/composerpress.php
@@ -10,7 +10,7 @@ use \Tomjn\ComposerPress\Plugin\WPackagistPlugin;
 class ComposerPress {
 
 	private $model = null;
-  const DEFAULT_FALLBACK_VENDOR = 'composerpress';
+	const DEFAULT_FALLBACK_VENDOR = 'composerpress';
 
 	public function __construct( Model $model ) {
 		$this->model = $model;
@@ -58,16 +58,16 @@ class ComposerPress {
 		}
 	}
 
-  /**
-   * Retrieve a setting.
-   *
-   * @param string $key Setting name.
-   * @param mixed $default Optional. Default setting value.
-   * @return mixed
-   */
-  public static function get_setting( $key, $default = false ) {
-    $option = get_option( 'composerpress' );
-    return (isset( $option[ $key ] ) && strlen($option[ $key ]) > 0) ? $option[ $key ] : $default;
-  }
+	/**
+	 * Retrieve a setting.
+	 *
+	 * @param string $key Setting name.
+	 * @param mixed $default Optional. Default setting value.
+	 * @return mixed
+	 */
+	public static function get_setting( $key, $default = false ) {
+		$option = get_option( 'composerpress' );
+		return (isset( $option[ $key ] ) && strlen($option[ $key ]) > 0) ? $option[ $key ] : $default;
+	}
 
 }

--- a/php/composerpress.php
+++ b/php/composerpress.php
@@ -2,9 +2,16 @@
 
 namespace Tomjn\ComposerPress;
 
+use \Tomjn\ComposerPress\Plugin\HGPlugin;
+use \Tomjn\ComposerPress\Plugin\GitPlugin;
+use \Tomjn\ComposerPress\Plugin\SVNPlugin;
+use \Tomjn\ComposerPress\Plugin\WPackagistPlugin;
+
 class ComposerPress {
 
 	private $model = null;
+  const DEFAULT_VENDOR = 'composerpress';
+
 	public function __construct( Model $model ) {
 		$this->model = $model;
 	}
@@ -37,21 +44,30 @@ class ComposerPress {
 			$filepath = WP_CONTENT_DIR.'/plugins/'.$key;
 			$plugin = null;
 			if ( file_exists( $fullpath.'.hg/' ) ) {
-				$plugin = new \Tomjn\ComposerPress\Plugin\HGPlugin( $fullpath, $filepath, $plugin_data );
+				$plugin = new HGPlugin( $fullpath, $filepath, $plugin_data );
 			} else if ( file_exists( $fullpath.'.git/' ) ) {
-				$plugin = new \Tomjn\ComposerPress\Plugin\GitPlugin( $fullpath, $filepath, $plugin_data );
+				$plugin = new GitPlugin( $fullpath, $filepath, $plugin_data );
 			} else if ( file_exists( $fullpath.'.svn/' ) ) {
-				$plugin = new \Tomjn\ComposerPress\Plugin\SVNPlugin( $fullpath, $filepath, $plugin_data );
+				$plugin = new SVNPlugin( $fullpath, $filepath, $plugin_data );
 			} else {
-				$plugin = new \Tomjn\ComposerPress\Plugin\WPackagistPlugin( $fullpath, $filepath, $plugin_data );
+				$plugin = new WPackagistPlugin( $fullpath, $filepath, $plugin_data );
 			}
 			if ( $plugin != null ) {
 				$this->model->add_plugin( $plugin );
 			}
 		}
 	}
+
+  /**
+   * Retrieve a setting.
+   *
+   * @param string $key Setting name.
+   * @param mixed $default Optional. Default setting value.
+   * @return mixed
+   */
+  public static function get_setting( $key, $default = false ) {
+    $option = get_option( 'composerpress' );
+    return (isset( $option[ $key ] ) && strlen($option[ $key ]) > 0) ? $option[ $key ] : $default;
+  }
+
 }
-
-
-
-

--- a/php/composerpress.php
+++ b/php/composerpress.php
@@ -10,7 +10,7 @@ use \Tomjn\ComposerPress\Plugin\WPackagistPlugin;
 class ComposerPress {
 
 	private $model = null;
-  const DEFAULT_VENDOR = 'composerpress';
+  const DEFAULT_FALLBACK_VENDOR = 'composerpress';
 
 	public function __construct( Model $model ) {
 		$this->model = $model;

--- a/php/plugin/wordpressplugin.php
+++ b/php/plugin/wordpressplugin.php
@@ -14,7 +14,7 @@ abstract class WordpressPlugin implements \Tomjn\ComposerPress\Plugin\PluginInte
 	}
 
 	public function get_name() {
-		$reponame = 'composerpress/'.sanitize_title( $this->plugin_data['Name'] );
+		$reponame = 'composerpress/'.sanitize_title( basename($this->path) );
 		if ( $this->has_composer() ) {
 			$composer = $this->get_composer();
 			if ( !empty( $composer->name ) ) {

--- a/php/plugin/wordpressplugin.php
+++ b/php/plugin/wordpressplugin.php
@@ -2,6 +2,8 @@
 
 namespace Tomjn\ComposerPress\Plugin;
 
+use \Tomjn\ComposerPress\ComposerPress;
+
 abstract class WordpressPlugin implements \Tomjn\ComposerPress\Plugin\PluginInterface {
 	protected $path;
 	protected $filepath;
@@ -14,7 +16,11 @@ abstract class WordpressPlugin implements \Tomjn\ComposerPress\Plugin\PluginInte
 	}
 
 	public function get_name() {
-		$reponame = 'composerpress/'.sanitize_title( basename($this->path) );
+
+    $namespace = ComposerPress::get_setting('vendor', ComposerPress::DEFAULT_FALLBACK_VENDOR );
+    $package = basename($this->path);
+
+		$reponame = sanitize_title($namespace).'/'.sanitize_title($package);
 		if ( $this->has_composer() ) {
 			$composer = $this->get_composer();
 			if ( !empty( $composer->name ) ) {

--- a/php/plugin/wordpressplugin.php
+++ b/php/plugin/wordpressplugin.php
@@ -17,8 +17,8 @@ abstract class WordpressPlugin implements \Tomjn\ComposerPress\Plugin\PluginInte
 
 	public function get_name() {
 
-    $namespace = ComposerPress::get_setting('vendor', ComposerPress::DEFAULT_FALLBACK_VENDOR );
-    $package = basename($this->path);
+		$namespace = ComposerPress::get_setting('vendor', ComposerPress::DEFAULT_FALLBACK_VENDOR );
+		$package = basename($this->path);
 
 		$reponame = sanitize_title($namespace).'/'.sanitize_title($package);
 		if ( $this->has_composer() ) {

--- a/php/toolpage.php
+++ b/php/toolpage.php
@@ -3,26 +3,109 @@
 namespace Tomjn\ComposerPress;
 
 class ToolPage {
+
 	protected $composerpress = null;
 	protected $model = null;
+
 	public function __construct( $composerpress, $model ) {
 		$this->composerpress = $composerpress;
 		$this->model = $model;
+
 		add_action( 'admin_menu', array( $this, 'on_admin_menu' ) );
+    add_action( 'admin_init', array( $this, 'on_admin_init' ) );
 	}
+
 
 	public function on_admin_menu() {
 		add_submenu_page( 'tools.php', 'Composer.json', 'Composer.json', 'manage_options', 'composer-json-page', array( $this, 'options_page' ) );
 	}
 
+  public function on_admin_init() {
+    // Composerpress custom settings
+    $this->register_settings();
+    $this->add_sections();
+    $this->add_settings();
+  }
+
+  /**
+   * Register settings.
+   */
+  public function register_settings() {
+    register_setting( 'composerpress', 'composerpress', array( $this, 'sanitize_settings' ) );
+  }
+
+  /**
+   * Add settings sections.
+   */
+  public function add_sections() {
+    add_settings_section(
+      'default',
+      __( 'Settings', 'composerpress' ),
+      '__return_null',
+      'composerpress'
+    );
+  }
+
+  /**
+   * Register individual settings.
+   */
+  public function add_settings() {
+    add_settings_field(
+      'vendor',
+      __( 'Fallback Vendor', 'composerpress' ),
+      array( $this, 'render_field_vendor' ),
+      'composerpress',
+      'default'
+    );
+  }
+
+
+  /**
+   * Display a field for defining the vendor.
+   */
+  public function render_field_vendor() {
+    $value = 	$this->composerpress::get_setting( 'vendor', '' );
+    ?>
+    <p>
+      <input type="text" name="composerpress[vendor]" id="composerpress-vendor" value="<?php echo esc_attr( $value ); ?>"><br>
+      <span class="description">Default is <code>composerpress</code></span>
+    </p>
+    <?php
+  }
+
+
+  /**
+   * Sanitize settings.
+   */
+  public function sanitize_settings( $value ) {
+    if ( ! empty( $value['vendor'] ) ) {
+      $value['vendor'] = sanitize_text_field( $value['vendor'] );
+    }
+    return $value;
+  }
+
+  /**
+   * Outputs composer.json page
+   */
 	function options_page() {
 		$this->composerpress->fill_model();
+
 		echo '<div class="wrap">';
 		echo '<h2>Composer.json</h2>';
 		echo '<style>.composerpress_json { padding:1em; background:#fff; border: 1px solid #ddd; }</style>';
+
+    // Prints composer.json
 		echo '<pre class="composerpress_json">';
 		echo $this->model->to_json();
 		echo '</pre>';
+
+    // Prints Settings Form
+    echo '<form action="options.php" method="post">';
+    settings_fields( 'composerpress' );
+    do_settings_sections( 'composerpress' );
+    submit_button();
+    echo '</form>';
+
 		echo '</div>';
 	}
 }

--- a/php/toolpage.php
+++ b/php/toolpage.php
@@ -12,7 +12,7 @@ class ToolPage {
 		$this->model = $model;
 
 		add_action( 'admin_menu', array( $this, 'on_admin_menu' ) );
-    add_action( 'admin_init', array( $this, 'on_admin_init' ) );
+		add_action( 'admin_init', array( $this, 'on_admin_init' ) );
 	}
 
 

--- a/php/toolpage.php
+++ b/php/toolpage.php
@@ -117,35 +117,31 @@ class ToolPage {
 		/**
 		 * Originally taken from: https://stackoverflow.com/questions/42266658/download-text-from-html-pre-tag
 		 */
-		function saveTextAsFile()
-			 {
-					 var textToWrite = document.querySelector('pre.composerpress_json').innerText;
-					 var textFileAsBlob = new Blob([textToWrite], {type:'text/plain'});
-					 var fileNameToSaveAs = "composer.json";
+		function saveTextAsFile() {
+			var textToWrite = document.querySelector('pre.composerpress_json').innerText;
+			var textFileAsBlob = new Blob([textToWrite], {type:'text/plain'});
+			var fileNameToSaveAs = "composer.json";
 
-					 var downloadLink = document.createElement("a");
-					 downloadLink.download = fileNameToSaveAs;
-					 downloadLink.innerHTML = "Download File";
-					 if (window.webkitURL != null)
-					 {
-							 // Chrome allows the link to be clicked without actually adding it to the DOM.
-							 downloadLink.href = window.webkitURL.createObjectURL(textFileAsBlob);
-					 }
-					 else
-					 {
-							 // Firefox requires the link to be added to the DOM before it can be clicked.
-							 downloadLink.href = window.URL.createObjectURL(textFileAsBlob);
-							 downloadLink.onclick = function(){
-								 document.body.removeChild(downloadLink);
-							 };
-							 downloadLink.style.display = "none";
-							 document.body.appendChild(downloadLink);
-					 }
-					 downloadLink.click();
-			 }
+			var downloadLink = document.createElement("a");
+			downloadLink.download = fileNameToSaveAs;
+			downloadLink.innerHTML = "Download File";
+			if (window.webkitURL != null) {
+				// Chrome allows the link to be clicked without actually adding it to the DOM.
+				downloadLink.href = window.webkitURL.createObjectURL(textFileAsBlob);
+			} else {
+				// Firefox requires the link to be added to the DOM before it can be clicked.
+				downloadLink.href = window.URL.createObjectURL(textFileAsBlob);
+				downloadLink.onclick = function(){
+					document.body.removeChild(downloadLink);
+				};
+				downloadLink.style.display = "none";
+				document.body.appendChild(downloadLink);
+			}
+			downloadLink.click();
+		}
 
-			 var button = document.getElementById('download');
-			 button.addEventListener('click', saveTextAsFile);
+		var button = document.getElementById('download');
+		button.addEventListener('click', saveTextAsFile);
 
 		</script>
 		<?php

--- a/php/toolpage.php
+++ b/php/toolpage.php
@@ -99,6 +99,8 @@ class ToolPage {
 		echo $this->model->to_json();
 		echo '</pre>';
 
+    echo '<button type="button" value="download" id="download" class="button button-secondary" style="width: 100%;">Download</button>';
+
     // Prints Settings Form
     echo '<form action="options.php" method="post">';
     settings_fields( 'composerpress' );
@@ -107,5 +109,42 @@ class ToolPage {
     echo '</form>';
 
 		echo '</div>';
+    ?>
+    <script>
+    /**
+     * Originally taken from: https://stackoverflow.com/questions/42266658/download-text-from-html-pre-tag
+     */
+    function saveTextAsFile()
+       {
+           var textToWrite = document.querySelector('pre.composerpress_json').innerText;
+           var textFileAsBlob = new Blob([textToWrite], {type:'text/plain'});
+           var fileNameToSaveAs = "composer.json";
+
+           var downloadLink = document.createElement("a");
+           downloadLink.download = fileNameToSaveAs;
+           downloadLink.innerHTML = "Download File";
+           if (window.webkitURL != null)
+           {
+               // Chrome allows the link to be clicked without actually adding it to the DOM.
+               downloadLink.href = window.webkitURL.createObjectURL(textFileAsBlob);
+           }
+           else
+           {
+               // Firefox requires the link to be added to the DOM before it can be clicked.
+               downloadLink.href = window.URL.createObjectURL(textFileAsBlob);
+               downloadLink.onclick = function(){
+                 document.body.removeChild(downloadLink);
+               };
+               downloadLink.style.display = "none";
+               document.body.appendChild(downloadLink);
+           }
+           downloadLink.click();
+       }
+
+       var button = document.getElementById('download');
+       button.addEventListener('click', saveTextAsFile);
+
+    </script>
+    <?php
 	}
 }

--- a/php/toolpage.php
+++ b/php/toolpage.php
@@ -94,6 +94,9 @@ class ToolPage {
 		echo '<h2>Composer.json</h2>';
 		echo '<style>.composerpress_json { padding:1em; background:#fff; border: 1px solid #ddd; }</style>';
 
+    // Readme.md link reminder
+    echo '<sub>Visit <a href="https://github.com/tomjn/composerpress" target="_blank">github.com/tomjn/composerpress</a> for more detailed information</sub>';
+
     // Prints composer.json
 		echo '<pre class="composerpress_json">';
 		echo $this->model->to_json();

--- a/php/toolpage.php
+++ b/php/toolpage.php
@@ -95,7 +95,7 @@ class ToolPage {
 		echo '<style>.composerpress_json { padding:1em; background:#fff; border: 1px solid #ddd; }</style>';
 
     // Readme.md link reminder
-    echo '<sub>Visit <a href="https://github.com/tomjn/composerpress" target="_blank">github.com/tomjn/composerpress</a> for more detailed information</sub>';
+    echo '<sub><a href="https://github.com/tomjn/composerpress" target="_blank">Readme</a> for usage information</sub>';
 
     // Prints composer.json
 		echo '<pre class="composerpress_json">';

--- a/php/toolpage.php
+++ b/php/toolpage.php
@@ -20,73 +20,73 @@ class ToolPage {
 		add_submenu_page( 'tools.php', 'Composer.json', 'Composer.json', 'manage_options', 'composer-json-page', array( $this, 'options_page' ) );
 	}
 
-  public function on_admin_init() {
-    // Composerpress custom settings
-    $this->register_settings();
-    $this->add_sections();
-    $this->add_settings();
-  }
+	public function on_admin_init() {
+		// Composerpress custom settings
+		$this->register_settings();
+		$this->add_sections();
+		$this->add_settings();
+	}
 
-  /**
-   * Register settings.
-   */
-  public function register_settings() {
-    register_setting( 'composerpress', 'composerpress', array( $this, 'sanitize_settings' ) );
-  }
+	/**
+	 * Register settings.
+	 */
+	public function register_settings() {
+		register_setting( 'composerpress', 'composerpress', array( $this, 'sanitize_settings' ) );
+	}
 
-  /**
-   * Add settings sections.
-   */
-  public function add_sections() {
-    add_settings_section(
-      'default',
-      __( 'Settings', 'composerpress' ),
-      '__return_null',
-      'composerpress'
-    );
-  }
+	/**
+	 * Add settings sections.
+	 */
+	public function add_sections() {
+		add_settings_section(
+			'default',
+			__( 'Settings', 'composerpress' ),
+			'__return_null',
+			'composerpress'
+		);
+	}
 
-  /**
-   * Register individual settings.
-   */
-  public function add_settings() {
-    add_settings_field(
-      'vendor',
-      __( 'Fallback Vendor', 'composerpress' ),
-      array( $this, 'render_field_vendor' ),
-      'composerpress',
-      'default'
-    );
-  }
-
-
-  /**
-   * Display a field for defining the vendor.
-   */
-  public function render_field_vendor() {
-    $value = 	$this->composerpress::get_setting( 'vendor', '' );
-    ?>
-    <p>
-      <input type="text" name="composerpress[vendor]" id="composerpress-vendor" value="<?php echo esc_attr( $value ); ?>"><br>
-      <span class="description">Default is <code>composerpress</code></span>
-    </p>
-    <?php
-  }
+	/**
+	 * Register individual settings.
+	 */
+	public function add_settings() {
+		add_settings_field(
+			'vendor',
+			__( 'Fallback Vendor', 'composerpress' ),
+			array( $this, 'render_field_vendor' ),
+			'composerpress',
+			'default'
+		);
+	}
 
 
-  /**
-   * Sanitize settings.
-   */
-  public function sanitize_settings( $value ) {
-    if ( ! empty( $value['vendor'] ) ) {
-      $value['vendor'] = sanitize_text_field( $value['vendor'] );
-    }
-    return $value;
-  }
+	/**
+	 * Display a field for defining the vendor.
+	 */
+	public function render_field_vendor() {
+		$value = 	$this->composerpress::get_setting( 'vendor', '' );
+		?>
+		<p>
+			<input type="text" name="composerpress[vendor]" id="composerpress-vendor" value="<?php echo esc_attr( $value ); ?>"><br>
+			<span class="description">Default is <code>composerpress</code></span>
+		</p>
+		<?php
+	}
 
-  /**
-   * Outputs composer.json page
-   */
+
+	/**
+	 * Sanitize settings.
+	 */
+	public function sanitize_settings( $value ) {
+		if ( ! empty( $value['vendor'] ) ) {
+			$value['vendor'] = sanitize_text_field( $value['vendor'] );
+		}
+		return $value;
+	}
+
+	/**
+	 * Outputs composer.json page
+	 */
 	function options_page() {
 		$this->composerpress->fill_model();
 
@@ -94,60 +94,60 @@ class ToolPage {
 		echo '<h2>Composer.json</h2>';
 		echo '<style>.composerpress_json { padding:1em; background:#fff; border: 1px solid #ddd; }</style>';
 
-    // Readme.md link reminder
-    echo '<sub><a href="https://github.com/tomjn/composerpress" target="_blank">Readme</a> for usage information</sub>';
+		// Readme.md link reminder
+		echo '<sub><a href="https://github.com/tomjn/composerpress" target="_blank">Readme</a> for usage information</sub>';
 
-    // Prints composer.json
+		// Prints composer.json
 		echo '<pre class="composerpress_json">';
 		echo $this->model->to_json();
 		echo '</pre>';
 
-    echo '<button type="button" value="download" id="download" class="button button-secondary" style="width: 100%;">Download</button>';
+		echo '<button type="button" value="download" id="download" class="button button-secondary" style="width: 100%;">Download</button>';
 
-    // Prints Settings Form
-    echo '<form action="options.php" method="post">';
-    settings_fields( 'composerpress' );
-    do_settings_sections( 'composerpress' );
-    submit_button();
-    echo '</form>';
+		// Prints Settings Form
+		echo '<form action="options.php" method="post">';
+		settings_fields( 'composerpress' );
+		do_settings_sections( 'composerpress' );
+		submit_button();
+		echo '</form>';
 
 		echo '</div>';
-    ?>
-    <script>
-    /**
-     * Originally taken from: https://stackoverflow.com/questions/42266658/download-text-from-html-pre-tag
-     */
-    function saveTextAsFile()
-       {
-           var textToWrite = document.querySelector('pre.composerpress_json').innerText;
-           var textFileAsBlob = new Blob([textToWrite], {type:'text/plain'});
-           var fileNameToSaveAs = "composer.json";
+		?>
+		<script>
+		/**
+		 * Originally taken from: https://stackoverflow.com/questions/42266658/download-text-from-html-pre-tag
+		 */
+		function saveTextAsFile()
+			 {
+					 var textToWrite = document.querySelector('pre.composerpress_json').innerText;
+					 var textFileAsBlob = new Blob([textToWrite], {type:'text/plain'});
+					 var fileNameToSaveAs = "composer.json";
 
-           var downloadLink = document.createElement("a");
-           downloadLink.download = fileNameToSaveAs;
-           downloadLink.innerHTML = "Download File";
-           if (window.webkitURL != null)
-           {
-               // Chrome allows the link to be clicked without actually adding it to the DOM.
-               downloadLink.href = window.webkitURL.createObjectURL(textFileAsBlob);
-           }
-           else
-           {
-               // Firefox requires the link to be added to the DOM before it can be clicked.
-               downloadLink.href = window.URL.createObjectURL(textFileAsBlob);
-               downloadLink.onclick = function(){
-                 document.body.removeChild(downloadLink);
-               };
-               downloadLink.style.display = "none";
-               document.body.appendChild(downloadLink);
-           }
-           downloadLink.click();
-       }
+					 var downloadLink = document.createElement("a");
+					 downloadLink.download = fileNameToSaveAs;
+					 downloadLink.innerHTML = "Download File";
+					 if (window.webkitURL != null)
+					 {
+							 // Chrome allows the link to be clicked without actually adding it to the DOM.
+							 downloadLink.href = window.webkitURL.createObjectURL(textFileAsBlob);
+					 }
+					 else
+					 {
+							 // Firefox requires the link to be added to the DOM before it can be clicked.
+							 downloadLink.href = window.URL.createObjectURL(textFileAsBlob);
+							 downloadLink.onclick = function(){
+								 document.body.removeChild(downloadLink);
+							 };
+							 downloadLink.style.display = "none";
+							 document.body.appendChild(downloadLink);
+					 }
+					 downloadLink.click();
+			 }
 
-       var button = document.getElementById('download');
-       button.addEventListener('click', saveTextAsFile);
+			 var button = document.getElementById('download');
+			 button.addEventListener('click', saveTextAsFile);
 
-    </script>
-    <?php
+		</script>
+		<?php
 	}
 }

--- a/plugin.php
+++ b/plugin.php
@@ -33,10 +33,10 @@ use  Tomjn\ComposerPress\ToolPage;
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require __DIR__ . '/vendor/autoload.php';
 } else if ( function_exists( 'wp_die' ) ) {
-  wp_die( 'This plugin install is incomplete, run <code>composer install</code> on the <code>wp-content/plugins/'.basename( __DIR__ ).'</code> plugin folder to install dependencies.</p><p>For instructions on installing composer:</p><ul><li><a href="http://getcomposer.org/doc/00-intro.md#installation-nix"> see here for *nix</a></li><li><a href="http://getcomposer.org/doc/00-intro.md#installation-windows">here for Windows</a></li></ul>' );
+	wp_die( 'This plugin install is incomplete, run <code>composer install</code> on the <code>wp-content/plugins/'.basename( __DIR__ ).'</code> plugin folder to install dependencies.</p><p>For instructions on installing composer:</p><ul><li><a href="http://getcomposer.org/doc/00-intro.md#installation-nix"> see here for *nix</a></li><li><a href="http://getcomposer.org/doc/00-intro.md#installation-windows">here for Windows</a></li></ul>' );
 } else {
 	error_log( 'composer install command needs to be ran on this plugin' );
-  return;
+	return;
 }
 
 $model = new Model();

--- a/plugin.php
+++ b/plugin.php
@@ -32,6 +32,11 @@ use  Tomjn\ComposerPress\ToolPage;
 
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require __DIR__ . '/vendor/autoload.php';
+} else if ( function_exists( 'wp_die' ) ) {
+  wp_die( 'This plugin install is incomplete, run <code>composer install</code> on the <code>wp-content/plugins/'.basename( __DIR__ ).'</code> plugin folder to install dependencies.</p><p>For instructions on installing composer:</p><ul><li><a href="http://getcomposer.org/doc/00-intro.md#installation-nix"> see here for *nix</a></li><li><a href="http://getcomposer.org/doc/00-intro.md#installation-windows">here for Windows</a></li></ul>' );
+} else {
+	error_log( 'composer install command needs to be ran on this plugin' );
+  return;
 }
 
 $model = new Model();


### PR DESCRIPTION
I made the changes based on what was said [here](https://github.com/tomjn/composerpress/commit/252166935173f50278baa0082cbf25482ea779db) and [here](https://github.com/tomjn/composerpress/commit/9a40819c852e8da4c65545138a49e5b2b2450e42#comments).

I have "taken" the functionality of setting a custom vendor name from the [satipress](https://github.com/blazersix/satispress) plugin (@bradyvercher have you ever thought of combining the features offered by these two plugins?)

_I hope_ I have not done too much trouble, this is my first ever Pull Request..



